### PR TITLE
"for YunoHost" is redudent, it's a yunohost app so it's for YunoHost ;)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Tyto app for YunoHost",
+    "name": "Tyto",
     "id": "tyto",
     "packaging_format": 1,
     "description": {


### PR DESCRIPTION
It's a small detail but this creates a weird thing when displayed on the yunohost admin. This is a YunoHost app so obviously it's for YunoHost ;)